### PR TITLE
Feature multichromedriverversions

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -80,7 +80,7 @@ module.exports = function (cdVersion) {
         if (platform !== 'win32') {
           fs.chmodSync(distPath, '755');
         }
-        _.rimraf(tempDir,(error) => {
+        _.rimraf(tempDir,{},(error) => {
           logger.error('remove temp dir failed!' + error);
         });
         logger.info('chromedriver local in %s', distPath);

--- a/lib/install.js
+++ b/lib/install.js
@@ -81,7 +81,7 @@ module.exports = function (cdVersion) {
           fs.chmodSync(distPath, '755');
         }
         _.rimraf(tempDir,(error) => {
-          logger.error('remove temp dir failed!'+error);
+          logger.error('remove temp dir failed!' + error);
         });
         logger.info('chromedriver local in %s', distPath);
         resolve();

--- a/lib/install.js
+++ b/lib/install.js
@@ -14,13 +14,13 @@ const Versions = require('./versions');
 
 const CDNURL = process.env.CHROMEDRIVER_CDNURL || 'https://chromedriver.storage.googleapis.com';
 
-function getDownloadUrl(version) {
+function getDownloadUrl (version) {
   var url = util.format('%s/%s/chromedriver_%s.zip', CDNURL, version, _.getExecFile(version));
   logger.info('chromedriver cdn url: %s', url);
   return url;
 }
 
-function UnZipStream(distPath) {
+function UnZipStream (distPath) {
   stream.Transform.call(this, {});
   this.data = [];
   this.distPath = distPath;
@@ -29,13 +29,13 @@ function UnZipStream(distPath) {
 
 util.inherits(UnZipStream, stream.Transform);
 
-UnZipStream.prototype._transform = function(chunk, encoding, callback) {
+UnZipStream.prototype._transform = function (chunk, encoding, callback) {
   this.data.push(chunk);
   this.dataLen += chunk.length;
   callback();
 };
 
-UnZipStream.prototype._flush = function(callback) {
+UnZipStream.prototype._flush = function (callback) {
   var buf = new Buffer(this.dataLen);
 
   for (var i = 0, len = this.data.length, pos = 0; i < len; i++) {
@@ -44,21 +44,21 @@ UnZipStream.prototype._flush = function(callback) {
   }
 
   var zip = new AdmZip(buf);
-  zip.extractEntryTo(getExecZipedName(),this.distPath,false,true);
+  zip.extractEntryTo(getExecZipedName(), this.distPath, false, true);
   callback();
 };
 
-function getExecZipedName(){
-    var fileName = _.platform.isWindows ? 'chromedriver.exe' : 'chromedriver';
-    return fileName;
+function getExecZipedName () {
+  var fileName = _.platform.isWindows ? 'chromedriver.exe' : 'chromedriver';
+  return fileName;
 }
-function getBinPath(chromedriverVersion){
+function getBinPath (chromedriverVersion) {
   var fileName = _.platform.isWindows ? 'chromedriver' + chromedriverVersion + '.exe' : 'chromedriver' + chromedriverVersion;
   var binPath = path.join(__dirname, '..', 'exec', fileName);
   return binPath;
 }
 
-module.exports = function(cdVersion) {
+module.exports = function (cdVersion) {
   let chromedriverVersions = new Versions();
   let platform = process.platform;
   let execFileName = getExecZipedName();
@@ -68,15 +68,15 @@ module.exports = function(cdVersion) {
   let url = getDownloadUrl(version);
   // chromedriver[.exe] file will be unziped to exec/${timestamp}/chromedriver[.exe] first
   // and then moved to exec/chromedriver2.xx[.exe]
-  let tempDir = path.join(path.dirname(distPath),(new Date()).valueOf().toString());
+  let tempDir = path.join(path.dirname(distPath), (new Date()).valueOf().toString());
   _.mkdir(path.dirname(distPath));
   _.mkdir(tempDir);
-  return new Promise((resolve,reject)=>{
+  return new Promise((resolve, reject) => {
     //logger.info("Promise executing:"+ url );
     request(url)
       .pipe(new UnZipStream(tempDir))
-      .on('finish', function() {
-        fs.renameSync(path.join(tempDir,execFileName),distPath);
+      .on('finish', function () {
+        fs.renameSync(path.join(tempDir, execFileName), distPath);
         if (platform !== 'win32') {
           fs.chmodSync(distPath, '755');
         }
@@ -84,8 +84,8 @@ module.exports = function(cdVersion) {
         logger.info('chromedriver local in %s', distPath);
         resolve();
       })
-      .on('error', function(err) {
+      .on('error', function (err) {
         return reject(err);
-    });
+      });
   });
 };

--- a/lib/install.js
+++ b/lib/install.js
@@ -12,14 +12,14 @@ const logger = require('./logger');
 //const Chromedriver = require('./macaca-chromedriver');
 const Versions = require('./versions');
 
-function getDownloadUrl (version) {
+function getDownloadUrl(version) {
   var CDNURL = process.env.CHROMEDRIVER_CDNURL || 'https://chromedriver.storage.googleapis.com';
   var url = util.format('%s/%s/chromedriver_%s.zip', CDNURL, version, _.getExecFile(version));
   logger.info('chromedriver cdn url: %s', url);
   return url;
 }
 
-function UnZipStream (distPath) {
+function UnZipStream(distPath) {
   stream.Transform.call(this, {});
   this.data = [];
   this.distPath = distPath;
@@ -47,11 +47,11 @@ UnZipStream.prototype._flush = function (callback) {
   callback();
 };
 
-function getExecZipedName () {
+function getExecZipedName() {
   var fileName = _.platform.isWindows ? 'chromedriver.exe' : 'chromedriver';
   return fileName;
 }
-function getBinPath (chromedriverVersion) {
+function getBinPath(chromedriverVersion) {
   var fileName = _.platform.isWindows ? 'chromedriver' + chromedriverVersion + '.exe' : 'chromedriver' + chromedriverVersion;
   var binPath = path.join(__dirname, '..', 'exec', fileName);
   return binPath;

--- a/lib/install.js
+++ b/lib/install.js
@@ -64,6 +64,7 @@ module.exports = function (cdVersion) {
   let execFileName = getExecZipedName();
 
   let version = cdVersion || chromedriverVersions.defaultVersion;
+  logger.info('version: %s', version);
   let distPath = getBinPath(version);
   let url = getDownloadUrl(version);
   // chromedriver[.exe] file will be unziped to exec/${timestamp}/chromedriver[.exe] first

--- a/lib/install.js
+++ b/lib/install.js
@@ -12,9 +12,8 @@ const logger = require('./logger');
 //const Chromedriver = require('./macaca-chromedriver');
 const Versions = require('./versions');
 
-const CDNURL = process.env.CHROMEDRIVER_CDNURL || 'https://chromedriver.storage.googleapis.com';
-
 function getDownloadUrl (version) {
+  var CDNURL = process.env.CHROMEDRIVER_CDNURL || 'https://chromedriver.storage.googleapis.com';
   var url = util.format('%s/%s/chromedriver_%s.zip', CDNURL, version, _.getExecFile(version));
   logger.info('chromedriver cdn url: %s', url);
   return url;

--- a/lib/install.js
+++ b/lib/install.js
@@ -80,7 +80,9 @@ module.exports = function (cdVersion) {
         if (platform !== 'win32') {
           fs.chmodSync(distPath, '755');
         }
-        fs.rmdirSync(tempDir);
+        _.rimraf(tempDir,(error) => {
+          logger.error('remove temp dir failed!'+error);
+        });
         logger.info('chromedriver local in %s', distPath);
         resolve();
       })

--- a/lib/install.js
+++ b/lib/install.js
@@ -9,12 +9,13 @@ const request = require('request');
 
 const _ = require('./helper');
 const logger = require('./logger');
-const Chromedriver = require('./macaca-chromedriver');
+//const Chromedriver = require('./macaca-chromedriver');
+const Versions = require('./versions');
 
 const CDNURL = process.env.CHROMEDRIVER_CDNURL || 'https://chromedriver.storage.googleapis.com';
 
-function getDownloadUrl() {
-  var url = util.format('%s/%s/chromedriver_%s.zip', CDNURL, Chromedriver.version, _.getExecFile(Chromedriver.version));
+function getDownloadUrl(version) {
+  var url = util.format('%s/%s/chromedriver_%s.zip', CDNURL, version, _.getExecFile(version));
   logger.info('chromedriver cdn url: %s', url);
   return url;
 }
@@ -43,29 +44,48 @@ UnZipStream.prototype._flush = function(callback) {
   }
 
   var zip = new AdmZip(buf);
-  zip.extractAllTo(path.join(this.distPath, '..'));
+  zip.extractEntryTo(getExecZipedName(),this.distPath,false,true);
   callback();
 };
 
-module.exports = function() {
-  var platform = process.platform;
-  var url = getDownloadUrl();
-  var distPath = Chromedriver.binPath;
+function getExecZipedName(){
+    var fileName = _.platform.isWindows ? 'chromedriver.exe' : 'chromedriver';
+    return fileName;
+}
+function getBinPath(chromedriverVersion){
+  var fileName = _.platform.isWindows ? 'chromedriver' + chromedriverVersion + '.exe' : 'chromedriver' + chromedriverVersion;
+  var binPath = path.join(__dirname, '..', 'exec', fileName);
+  return binPath;
+}
+
+module.exports = function(cdVersion) {
+  let chromedriverVersions = new Versions();
+  let platform = process.platform;
+  let execFileName = getExecZipedName();
+
+  let version = cdVersion || chromedriverVersions.defaultVersion;
+  let distPath = getBinPath(version);
+  let url = getDownloadUrl(version);
+  // chromedriver[.exe] file will be unziped to exec/${timestamp}/chromedriver[.exe] first
+  // and then moved to exec/chromedriver2.xx[.exe]
+  let tempDir = path.join(path.dirname(distPath),(new Date()).valueOf().toString());
   _.mkdir(path.dirname(distPath));
-
-  return new Promise(function(resolve, reject) {
+  _.mkdir(tempDir);
+  return new Promise((resolve,reject)=>{
+    //logger.info("Promise executing:"+ url );
     request(url)
-      .pipe(new UnZipStream(distPath))
+      .pipe(new UnZipStream(tempDir))
       .on('finish', function() {
-        logger.info('chromedriver local in %s', distPath);
-
+        fs.renameSync(path.join(tempDir,execFileName),distPath);
         if (platform !== 'win32') {
           fs.chmodSync(distPath, '755');
         }
+        fs.rmdirSync(tempDir);
+        logger.info('chromedriver local in %s', distPath);
         resolve();
       })
       .on('error', function(err) {
         return reject(err);
-      });
+    });
   });
 };

--- a/lib/macaca-chromedriver.js
+++ b/lib/macaca-chromedriver.js
@@ -8,6 +8,7 @@ const childProcess = require('child_process');
 const _ = require('./helper');
 const logger = require('./logger');
 const DriverProxy = require('./proxy');
+const Install = require('./install');
 const Versions = require('./versions');
 
 // Deprecated
@@ -45,7 +46,12 @@ class ChromeDriver extends EventEmitter {
     if (_.isExistedFile(this.binPath)) {
       logger.info(`chromedriver bin path: ${this.binPath}`);
     } else {
-      logger.error('chromedriver bin path not found');
+      logger.warn(`chromedriver bin path (${this.binPath}) not found, try to download first!`);
+      Install(this.version).then(() => {
+        logger.info(`Install chromedriver version ${this.version} succeed!`);
+      }).catch(() => {
+        logger.error(`Install chromedriver version ${this.version} failed!`);
+      });
     }
   }
 

--- a/lib/macaca-chromedriver.js
+++ b/lib/macaca-chromedriver.js
@@ -19,7 +19,7 @@ const binPath = path.join(__dirname, '..', 'exec', fileName);
 const proxyPort = parseInt(process.env.MACACA_CHROMEDRIVER_PORT || 9515, 10);
 
 class ChromeDriver extends EventEmitter {
-  constructor (options) {
+  constructor(options) {
     super();
     Object.assign(this, {
       proxyHost: 'localhost',
@@ -37,12 +37,12 @@ class ChromeDriver extends EventEmitter {
     this.init();
   }
 
-  init () {
+  init() {
     this.checkBinPath();
     this.initPorxy();
   }
 
-  checkBinPath () {
+  checkBinPath() {
     if (_.isExistedFile(this.binPath)) {
       logger.info(`chromedriver bin path: ${this.binPath}`);
     } else {
@@ -55,7 +55,7 @@ class ChromeDriver extends EventEmitter {
     }
   }
 
-  getChromedriverVersion () {
+  getChromedriverVersion() {
     if (process.env.WEBVIEW_VERSION) {
       return this.versions.getVersionFromWebviewVersion(process.env.WEBVIEW_VERSION);
     } else if (this.webviewVersion) {
@@ -67,7 +67,7 @@ class ChromeDriver extends EventEmitter {
     }
   }
 
-  initPorxy () {
+  initPorxy() {
     this.proxy = new DriverProxy({
       proxyHost: this.proxyHost,
       proxyPort: this.proxyPort,
@@ -75,7 +75,7 @@ class ChromeDriver extends EventEmitter {
     });
   }
 
-  waitReadyStatus () {
+  waitReadyStatus() {
     logger.info('chromedriver starting success.');
 
     return _.retry(this.getStatus.bind(this), 1000, 20)
@@ -91,27 +91,27 @@ class ChromeDriver extends EventEmitter {
       });
   }
 
-  sendCommand (url, method, body) {
+  sendCommand(url, method, body) {
     return this.proxy.send(url, method, body);
   }
 
-  getStatus () {
+  getStatus() {
     return this.sendCommand('/status', 'GET');
   }
 
-  getBinPath (chromedriverVersion) {
+  getBinPath(chromedriverVersion) {
     var fileName = _.platform.isWindows ? 'chromedriver' + chromedriverVersion + '.exe' : 'chromedriver' + chromedriverVersion;
     var binPath = path.join(__dirname, '..', 'exec', fileName);
     return binPath;
   }
 
-  createSession () {
+  createSession() {
     return this.sendCommand('/session', 'POST', {
       desiredCapabilities: this.capabilities
     });
   }
 
-  start (caps) {
+  start(caps) {
     this.capabilities = caps;
 
     return this.starting()
@@ -124,7 +124,7 @@ class ChromeDriver extends EventEmitter {
       });
   }
 
-  starting () {
+  starting() {
     return detect(this.proxyPort).then(port => {
       return new Promise((resolve, reject) => {
         this.proxy.proxyPort = this.proxyPort = port;
@@ -166,7 +166,7 @@ class ChromeDriver extends EventEmitter {
     });
   }
 
-  stop () {
+  stop() {
     this.chromedriver && this.chromedriver.kill();
   }
 }

--- a/lib/macaca-chromedriver.js
+++ b/lib/macaca-chromedriver.js
@@ -18,7 +18,7 @@ const binPath = path.join(__dirname, '..', 'exec', fileName);
 const proxyPort = parseInt(process.env.MACACA_CHROMEDRIVER_PORT || 9515, 10);
 
 class ChromeDriver extends EventEmitter {
-  constructor(options) {
+  constructor (options) {
     super();
     Object.assign(this, {
       proxyHost: 'localhost',
@@ -36,31 +36,32 @@ class ChromeDriver extends EventEmitter {
     this.init();
   }
 
-  init() {
+  init () {
     this.checkBinPath();
     this.initPorxy();
   }
 
-  checkBinPath() {
+  checkBinPath () {
     if (_.isExistedFile(this.binPath)) {
       logger.info(`chromedriver bin path: ${this.binPath}`);
     } else {
       logger.error('chromedriver bin path not found');
     }
   }
-  getChromedriverVersion(){
-    if(process.env.WEBVIEW_VERSION){
+
+  getChromedriverVersion () {
+    if (process.env.WEBVIEW_VERSION) {
       return this.versions.getVersionFromWebviewVersion(process.env.WEBVIEW_VERSION);
-    }else if(this.webviewVersion){
+    } else if (this.webviewVersion) {
       return this.versions.getVersionFromWebviewVersion(this.webviewVersion);
-    }else if(process.env.CHROMEDRIVER_VERSION){
+    } else if (process.env.CHROMEDRIVER_VERSION) {
       return process.env.CHROMEDRIVER_VERSION;
-    }else{
+    } else {
       return this.versions.defaultVersion;
     }
   }
 
-  initPorxy() {
+  initPorxy () {
     this.proxy = new DriverProxy({
       proxyHost: this.proxyHost,
       proxyPort: this.proxyPort,
@@ -68,56 +69,56 @@ class ChromeDriver extends EventEmitter {
     });
   }
 
-  waitReadyStatus() {
+  waitReadyStatus () {
     logger.info('chromedriver starting success.');
 
     return _.retry(this.getStatus.bind(this), 1000, 20)
       .then(() => _.retry(this.createSession.bind(this), 1000, 20)
-      .then(data => {
-        this.emit(ChromeDriver.EVENT_READY, data);
-      })
+        .then(data => {
+          this.emit(ChromeDriver.EVENT_READY, data);
+        })
+        .catch(err => {
+          logger.debug(`create chromedriver session failed with: ${err}`);
+        }))
       .catch(err => {
-        logger.debug(`create chromedriver session failed with: ${err}`);
-      }))
-      .catch(err => {
-      logger.debug(`get chromedriver ready status failed with: ${err}`);
-    });
+        logger.debug(`get chromedriver ready status failed with: ${err}`);
+      });
   }
 
-  sendCommand(url, method, body) {
+  sendCommand (url, method, body) {
     return this.proxy.send(url, method, body);
   }
 
-  getStatus() {
+  getStatus () {
     return this.sendCommand('/status', 'GET');
   }
 
-  getBinPath(chromedriverVersion){
+  getBinPath (chromedriverVersion) {
     var fileName = _.platform.isWindows ? 'chromedriver' + chromedriverVersion + '.exe' : 'chromedriver' + chromedriverVersion;
     var binPath = path.join(__dirname, '..', 'exec', fileName);
     return binPath;
   }
 
-  createSession() {
+  createSession () {
     return this.sendCommand('/session', 'POST', {
       desiredCapabilities: this.capabilities
     });
   }
 
-  start(caps) {
+  start (caps) {
     this.capabilities = caps;
 
     return this.starting()
       .then(this.waitReadyStatus.bind(this))
       .catch(err => {
         logger.warn('chromedriver starting failed.');
-        setTimeout(function() {
+        setTimeout(function () {
           throw err;
         });
       });
   }
 
-  starting() {
+  starting () {
     return detect(this.proxyPort).then(port => {
       return new Promise((resolve, reject) => {
         this.proxy.proxyPort = this.proxyPort = port;
@@ -159,7 +160,7 @@ class ChromeDriver extends EventEmitter {
     });
   }
 
-  stop() {
+  stop () {
     this.chromedriver && this.chromedriver.kill();
   }
 }

--- a/lib/macaca-chromedriver.js
+++ b/lib/macaca-chromedriver.js
@@ -8,8 +8,11 @@ const childProcess = require('child_process');
 const _ = require('./helper');
 const logger = require('./logger');
 const DriverProxy = require('./proxy');
+const Versions = require('./versions');
 
-const fileName = _.platform.isWindows ? 'chromedriver.exe' : 'chromedriver';
+// Deprecated
+const fileName = _.platform.isWindows ? 'chromedriver' + Versions.defaultVersion + '.exe' : 'chromedriver' + Versions.defaultVersion;
+// Deprecated
 const binPath = path.join(__dirname, '..', 'exec', fileName);
 
 const proxyPort = parseInt(process.env.MACACA_CHROMEDRIVER_PORT || 9515, 10);
@@ -20,9 +23,12 @@ class ChromeDriver extends EventEmitter {
     Object.assign(this, {
       proxyHost: 'localhost',
       proxyPort: proxyPort,
-      urlBase: 'wd/hub'
+      urlBase: 'wd/hub',
+      webviewVersion: 44
     }, options || {});
-    this.binPath = binPath;
+    this.versions = new Versions();
+    this.version = this.getChromedriverVersion();
+    this.binPath = this.getBinPath(this.version);
     this.proxy = null;
     this.chromedriver = null;
     this.capabilities = null;
@@ -40,6 +46,17 @@ class ChromeDriver extends EventEmitter {
       logger.info(`chromedriver bin path: ${this.binPath}`);
     } else {
       logger.error('chromedriver bin path not found');
+    }
+  }
+  getChromedriverVersion(){
+    if(process.env.WEBVIEW_VERSION){
+      return this.versions.getVersionFromWebviewVersion(process.env.WEBVIEW_VERSION);
+    }else if(this.webviewVersion){
+      return this.versions.getVersionFromWebviewVersion(this.webviewVersion);
+    }else if(process.env.CHROMEDRIVER_VERSION){
+      return process.env.CHROMEDRIVER_VERSION;
+    }else{
+      return this.versions.defaultVersion;
     }
   }
 
@@ -73,6 +90,12 @@ class ChromeDriver extends EventEmitter {
 
   getStatus() {
     return this.sendCommand('/status', 'GET');
+  }
+
+  getBinPath(chromedriverVersion){
+    var fileName = _.platform.isWindows ? 'chromedriver' + chromedriverVersion + '.exe' : 'chromedriver' + chromedriverVersion;
+    var binPath = path.join(__dirname, '..', 'exec', fileName);
+    return binPath;
   }
 
   createSession() {
@@ -156,8 +179,11 @@ ChromeDriver.stop = () => {
 ChromeDriver.EVENT_READY = 'ready';
 ChromeDriver.EVENT_ERROR = 'error';
 
+//deprecated
 ChromeDriver.binPath = binPath;
+//deprecated
 ChromeDriver.fileName = fileName;
-ChromeDriver.version = process.env.CHROMEDRIVER_VERSION || '2.20';
+//deprecated
+ChromeDriver.version = process.env.CHROMEDRIVER_VERSION || Versions.defaultVersion;
 
 module.exports = ChromeDriver;

--- a/lib/macaca-chromedriver.js
+++ b/lib/macaca-chromedriver.js
@@ -24,7 +24,7 @@ class ChromeDriver extends EventEmitter {
       proxyHost: 'localhost',
       proxyPort: proxyPort,
       urlBase: 'wd/hub',
-      webviewVersion: 44
+      webviewVersion: undefined
     }, options || {});
     this.versions = new Versions();
     this.version = this.getChromedriverVersion();

--- a/lib/versions.js
+++ b/lib/versions.js
@@ -4,40 +4,42 @@
 'use strict';
 
 class ChromedriverVersion {
-    constructor() {
-        this.defaultVersion = '2.20';
-        this.versionMap = [
-            {chromedriverVersion:'2.30', webviewVersions:[58,60]},
-            {chromedriverVersion:'2.28', webviewVersions:[55,57]},
-            {chromedriverVersion:'2.26', webviewVersions:[53,55]},
-            {chromedriverVersion:'2.23', webviewVersions:[51,53]},
-            {chromedriverVersion:'2.21', webviewVersions:[46,50]},
-            {chromedriverVersion:'2.20', webviewVersions:[43,48]},
-            {chromedriverVersion:'2.14', webviewVersions:[39,42]},
-            {chromedriverVersion:'2.12', webviewVersions:[36,40]}
-        ];
+  constructor () {
+    this.defaultVersion = '2.20';
+    this.versionMap = [
+      {chromedriverVersion: '2.30', webviewVersions: [58, 60]},
+      {chromedriverVersion: '2.28', webviewVersions: [55, 57]},
+      {chromedriverVersion: '2.26', webviewVersions: [53, 55]},
+      {chromedriverVersion: '2.23', webviewVersions: [51, 53]},
+      {chromedriverVersion: '2.21', webviewVersions: [46, 50]},
+      {chromedriverVersion: '2.20', webviewVersions: [43, 48]},
+      {chromedriverVersion: '2.14', webviewVersions: [39, 42]},
+      {chromedriverVersion: '2.12', webviewVersions: [36, 40]}
+    ];
+  }
+
+  // get chromedriver version from webview version
+  // if nothing match. return default version 2.20
+  getVersionFromWebviewVersion (webviewVersion) {
+    if (!webviewVersion) {
+      return this.defaultVersion;
     }
-    // get chromedriver version from webview version
-    // if nothing match. return default version 2.20
-    getVersionFromWebviewVersion(webviewVersion){
-        if(!webviewVersion){
-            return this.defaultVersion;
-        }
-        for(var i = 0;i < this.versionMap.length; i++){
-            if(webviewVersion >= this.versionMap[i].webviewVersions[0] && webviewVersion <= this.versionMap[i].webviewVersions[1]){
-                return this.versionMap[i].chromedriverVersion;
-            }
-        }
-        return this.defaultVersion;
+    for (var i = 0; i < this.versionMap.length; i++) {
+      if (webviewVersion >= this.versionMap[i].webviewVersions[0] && webviewVersion <= this.versionMap[i].webviewVersions[1]) {
+        return this.versionMap[i].chromedriverVersion;
+      }
     }
-    // get an array of chromedriver versions which we need install at the very moment of installation.
-    getVersions(){
-        var arr = [];
-        for(var i = 0;i < this.versionMap.length; i++){
-            arr.push(this.versionMap[i].chromedriverVersion);
-        }
-        return arr;
+    return this.defaultVersion;
+  }
+
+  // get an array of chromedriver versions which we need install at the very moment of installation.
+  getVersions () {
+    var arr = [];
+    for (var i = 0; i < this.versionMap.length; i++) {
+      arr.push(this.versionMap[i].chromedriverVersion);
     }
+    return arr;
+  }
 }
 ChromedriverVersion.defaultVersion = '2.20';
 module.exports = ChromedriverVersion;

--- a/lib/versions.js
+++ b/lib/versions.js
@@ -2,6 +2,7 @@
  * Created by kyowang on 2017/7/11.
  */
 'use strict';
+const logger = require('./logger');
 
 class ChromedriverVersion {
   constructor() {
@@ -29,6 +30,8 @@ class ChromedriverVersion {
         return this.versionMap[i].chromedriverVersion;
       }
     }
+    logger.error(`No proper chromedriver version found for webview version: ${webviewVersion}!`);
+    logger.error(`Use version: ${this.defaultVersion} instead!`);
     return this.defaultVersion;
   }
 

--- a/lib/versions.js
+++ b/lib/versions.js
@@ -1,0 +1,43 @@
+/**
+ * Created by kyowang on 2017/7/11.
+ */
+'use strict';
+
+class ChromedriverVersion {
+    constructor() {
+        this.defaultVersion = '2.20';
+        this.versionMap = [
+            {chromedriverVersion:'2.30', webviewVersions:[58,60]},
+            {chromedriverVersion:'2.28', webviewVersions:[55,57]},
+            {chromedriverVersion:'2.26', webviewVersions:[53,55]},
+            {chromedriverVersion:'2.23', webviewVersions:[51,53]},
+            {chromedriverVersion:'2.21', webviewVersions:[46,50]},
+            {chromedriverVersion:'2.20', webviewVersions:[43,48]},
+            {chromedriverVersion:'2.14', webviewVersions:[39,42]},
+            {chromedriverVersion:'2.12', webviewVersions:[36,40]}
+        ];
+    }
+    // get chromedriver version from webview version
+    // if nothing match. return default version 2.20
+    getVersionFromWebviewVersion(webviewVersion){
+        if(!webviewVersion){
+            return this.defaultVersion;
+        }
+        for(var i = 0;i < this.versionMap.length; i++){
+            if(webviewVersion >= this.versionMap[i].webviewVersions[0] && webviewVersion <= this.versionMap[i].webviewVersions[1]){
+                return this.versionMap[i].chromedriverVersion;
+            }
+        }
+        return this.defaultVersion;
+    }
+    // get an array of chromedriver versions which we need install at the very moment of installation.
+    getVersions(){
+        var arr = [];
+        for(var i = 0;i < this.versionMap.length; i++){
+            arr.push(this.versionMap[i].chromedriverVersion);
+        }
+        return arr;
+    }
+}
+ChromedriverVersion.defaultVersion = '2.20';
+module.exports = ChromedriverVersion;

--- a/lib/versions.js
+++ b/lib/versions.js
@@ -4,7 +4,7 @@
 'use strict';
 
 class ChromedriverVersion {
-  constructor () {
+  constructor() {
     this.defaultVersion = '2.20';
     this.versionMap = [
       {chromedriverVersion: '2.30', webviewVersions: [58, 60]},
@@ -20,7 +20,7 @@ class ChromedriverVersion {
 
   // get chromedriver version from webview version
   // if nothing match. return default version 2.20
-  getVersionFromWebviewVersion (webviewVersion) {
+  getVersionFromWebviewVersion(webviewVersion) {
     if (!webviewVersion) {
       return this.defaultVersion;
     }
@@ -33,7 +33,7 @@ class ChromedriverVersion {
   }
 
   // get an array of chromedriver versions which we need install at the very moment of installation.
-  getVersions () {
+  getVersions() {
     var arr = [];
     for (var i = 0; i < this.versionMap.length; i++) {
       arr.push(this.versionMap[i].chromedriverVersion);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "macaca-chromedriver",
-  "version": "1.0.31",
+  "version": "1.0.33",
   "description": "Node.js wrapper for the selenium chromedriver.",
   "keywords": [
     "macaca",

--- a/test/macaca-chromedriver.test.js
+++ b/test/macaca-chromedriver.test.js
@@ -25,12 +25,4 @@ describe('test', function() {
       console.log(err);
     }
   });
-  it('install specific chromedriver version', function *() {
-    process.env.CHROMEDRIVER_CDNURL='http://cdn.npm.taobao.org/dist/chromedriver';
-    Install('2.30').then(() => {
-      logger.info(`Install chromedriver version ${this.version} succeed!`);
-    }).catch(() => {
-      logger.error(`Install chromedriver version ${this.version} failed!`);
-    });
-  });
 });

--- a/test/macaca-chromedriver.test.js
+++ b/test/macaca-chromedriver.test.js
@@ -2,6 +2,7 @@
 
 var ChromeDriver = require('..');
 var detectPort = require('detect-port');
+var Install = require('../lib/install');
 
 describe('test', function() {
   it('should be ok', function() {
@@ -23,5 +24,12 @@ describe('test', function() {
     } catch (err) {
       console.log(err);
     }
+  });
+  it('install specific chromedriver version', function *() {
+    Install('2.30').then(() => {
+      logger.info(`Install chromedriver version ${this.version} succeed!`);
+    }).catch(() => {
+      logger.error(`Install chromedriver version ${this.version} failed!`);
+    });
   });
 });

--- a/test/macaca-chromedriver.test.js
+++ b/test/macaca-chromedriver.test.js
@@ -26,6 +26,7 @@ describe('test', function() {
     }
   });
   it('install specific chromedriver version', function *() {
+    process.env.CHROMEDRIVER_CDNURL='http://cdn.npm.taobao.org/dist/chromedriver';
     Install('2.30').then(() => {
       logger.info(`Install chromedriver version ${this.version} succeed!`);
     }).catch(() => {


### PR DESCRIPTION
Feature multichromedriverversions，
the purpose is to support most webview versions by starting corresponding chromedriver version.
at the beginning like before just download version 2.20 when trying to start chromedriver,
there will be a chance to indicate webview version or chromedriver version, when the bin file is not exists,
will try to download automatically  first and then start the correct version.