### PR TITLE
Bugfix sync call issue

### DIFF
--- a/lib/macaca-chromedriver.js
+++ b/lib/macaca-chromedriver.js
@@ -45,6 +45,7 @@ class ChromeDriver extends EventEmitter {
   checkBinPath() {
     if (_.isExistedFile(this.binPath)) {
       logger.info(`chromedriver bin path: ${this.binPath}`);
+      this.emit(ChromeDriver.BIN_READY, 'OK');
     } else {
       logger.warn(`chromedriver bin path (${this.binPath}) not found, try to download first!`);
       Install(this.version).then(() => {

--- a/lib/macaca-chromedriver.js
+++ b/lib/macaca-chromedriver.js
@@ -49,7 +49,9 @@ class ChromeDriver extends EventEmitter {
       logger.warn(`chromedriver bin path (${this.binPath}) not found, try to download first!`);
       Install(this.version).then(() => {
         logger.info(`Install chromedriver version ${this.version} succeed!`);
+        this.emit(ChromeDriver.BIN_READY, 'OK');
       }).catch(() => {
+        this.emit(ChromeDriver.EVENT_ERROR, 'bin file check failed');
         logger.error(`Install chromedriver version ${this.version} failed!`);
       });
     }
@@ -57,12 +59,16 @@ class ChromeDriver extends EventEmitter {
 
   getChromedriverVersion() {
     if (process.env.WEBVIEW_VERSION) {
+      logger.info(`env.WEBVIEW_VERSION found ${process.env.WEBVIEW_VERSION} use it!`);
       return this.versions.getVersionFromWebviewVersion(process.env.WEBVIEW_VERSION);
     } else if (this.webviewVersion) {
+      logger.info(`this.webviewVersion found ${this.webviewVersion} use it!`);
       return this.versions.getVersionFromWebviewVersion(this.webviewVersion);
     } else if (process.env.CHROMEDRIVER_VERSION) {
+      logger.info(`process.env.CHROMEDRIVER_VERSION found ${process.env.CHROMEDRIVER_VERSION} use it!`);
       return process.env.CHROMEDRIVER_VERSION;
     } else {
+      logger.info(`use default chromedriver version!`);
       return this.versions.defaultVersion;
     }
   }
@@ -184,6 +190,7 @@ ChromeDriver.stop = () => {
 };
 
 ChromeDriver.EVENT_READY = 'ready';
+ChromeDriver.BIN_READY = 'bin_ready';
 ChromeDriver.EVENT_ERROR = 'error';
 
 //deprecated

--- a/lib/macaca-chromedriver.js
+++ b/lib/macaca-chromedriver.js
@@ -31,6 +31,7 @@ class ChromeDriver extends EventEmitter {
     this.version = this.getChromedriverVersion();
     this.binPath = this.getBinPath(this.version);
     this.proxy = null;
+    this.binPathReady = false;
     this.chromedriver = null;
     this.capabilities = null;
     this.sessionId = null;
@@ -45,7 +46,7 @@ class ChromeDriver extends EventEmitter {
   checkBinPath() {
     if (_.isExistedFile(this.binPath)) {
       logger.info(`chromedriver bin path: ${this.binPath}`);
-      this.emit(ChromeDriver.BIN_READY, 'OK');
+      this.binPathReady = true;
     } else {
       logger.warn(`chromedriver bin path (${this.binPath}) not found, try to download first!`);
       Install(this.version).then(() => {


### PR DESCRIPTION
Test log:
the senario is macaca-android will detect device webview version and pass to macaca-chromedriver.


>> responseHandler.js:11:12 [master] pid:26186 Recieve HTTP Request from Client[2017-07-14 18:44:03]: method: GET url: /wd/hub/session/27780e60-af2b-4a7e-82a7-5e7819ef2280/contexts, jsonBody: {}
>> this.webviewVersion found 50 use it!
>> macaca-chromedriver.js:49:14 [master] pid:26186 chromedriver bin path (/usr/local/node-v6.10.3-linux-x64/lib/node_modules/macaca-android/node_modules/.1.0.31@macaca-chromedriver/exec/chromedriver2.21) not found, try to download first!
>> version: 2.21
>> chromedriver cdn url: http://cdn.npm.taobao.org/dist/chromedriver/2.21/chromedriver_linux64.zip
>> chromedriver local in /usr/local/node-v6.10.3-linux-x64/lib/node_modules/macaca-android/node_modules/.1.0.31@macaca-chromedriver/exec/chromedriver2.21
>> Install chromedriver version 2.21 succeed!
>> chromedriver bin file ready: OK
>> starting chromedriver service!
>> Starting ChromeDriver 2.21.371461 (633e689b520b25f3e264a2ede6b74ccc23cb636a) on port 9515
Only local connections are allowed.

>> chromedriver starting success.
